### PR TITLE
Modify the logic of split train test data

### DIFF
--- a/src/analysis.py
+++ b/src/analysis.py
@@ -12,9 +12,9 @@ from non_temporal_modelling import ClassificationProcedure, ClassificationEvalua
 ### Read in cleaned data and defined reoccruing objects ###
 df = pd.read_csv("../dataset/data_cleaned.csv")
 sensor_columns = [
-    col for col in df.columns[2:15] if "Linear" not in col
+    col for col in df.columns[3:16] if "Linear" not in col
 ]  # [col for col in df.columns[2:15]]
-label_columns = [col for col in df.columns[15:]]
+label_columns = [col for col in df.columns[16:]]
 milliseconds_per_instance = (
     df.loc[1, "Time difference (s)"] * 1000
 )  # Compute number of milliseconds covered by an instance
@@ -24,7 +24,7 @@ milliseconds_per_instance = (
 _ = describe(df)
 
 # Reduce df to relevant data (cut out time and linear acceleration - essentially same as accelerometer)
-df = df[sensor_columns + label_columns]
+df = df[["ID"] + sensor_columns + label_columns]
 # [col for col in df.columns]
 
 

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -29,6 +29,7 @@ _ = describe(df)
 ## Outlier Analysis
 outlier = OutlierDetectionDistribution(df, sensor_columns)
 chauvenet_df = outlier.chauvenet(C=2)
+# outlier.visualize_chauvenet_outlier(chauvenet_df)
 mixture_df = outlier.mixture_model(n_components=3)
 
 ## Missing & General Data Transformation
@@ -40,7 +41,7 @@ df = transform.low_pass_filter(sampling_frequency=(1000 / granularity),
                                cutoff_frequency=1.5,
                                order=10,
                                phase_shift=True)
-
+# transform.visualize_low_pass()
 
 ### Feature Engineering ###
 # Initialize the window sizes to the number of instances representing 5 seconds

--- a/src/data_clean_label.py
+++ b/src/data_clean_label.py
@@ -178,6 +178,15 @@ def fill_missing_value(
     
     return df
 
+def assign_id_per_movement(
+    df: pd.DataFrame, based: int
+) -> pd.DataFrame:
+    movement_start_idx = list(df[df["Time difference (s)"] == 0].index) + [df.shape[0]]
+    df.insert(0, "ID", 0)
+    for i in range(len(movement_start_idx) - 1):
+        df.loc[movement_start_idx[i]:movement_start_idx[i+1], "ID"] = i
+
+    return df
 
 filepath = "/Users/thl/Downloads/"
 round_num = 3
@@ -210,4 +219,6 @@ for round in range(1, round_num + 1):
             df_cleaned.reset_index(level=0, drop=True, inplace = True)
             df_cleaned = pd.concat([df_cleaned, df_result], ignore_index=True)
 
+# assign id
+df_cleaned = assign_id_per_movement(df_cleaned)
 df_cleaned.to_csv(f"../dataset/data_cleaned_{granularity}.csv", index=False)

--- a/src/data_transformation.py
+++ b/src/data_transformation.py
@@ -1,22 +1,19 @@
 import pandas as pd
+import plotly.graph_objects as go
 from scipy.signal import butter, lfilter, filtfilt
+from plotly.subplots import make_subplots
+from typing import List
+
 
 class DataTransformation:
-
-    def __init__(
-        self, 
-        df: pd.DataFrame, 
-        columns: list[str]
-    ):
-
+    def __init__(self, df: pd.DataFrame, columns: List[str]):
+        self.df_original = df.copy()
         self.df = df.copy()
         self.columns = columns
 
     # Interpolate the dataset based on previous/next values..
-    def impute_interpolate(
-        self
-    ) -> pd.DataFrame:
-        
+    def impute_interpolate(self) -> pd.DataFrame:
+
         self.df[self.columns] = self.df[self.columns].interpolate().ffill().bfill()
 
         return self.df
@@ -30,7 +27,7 @@ class DataTransformation:
     ):
         # http://stackoverflow.com/questions/12093594/how-to-implement-band-pass-butterworth-filter-with-scipy-signal-butter
         # Cutoff frequencies are expressed as the fraction of the Nyquist frequency, which is half the sampling frequency
-        
+
         nyq = 0.5 * sampling_frequency
         for col in self.columns:
             cut = cutoff_frequency / nyq
@@ -39,6 +36,86 @@ class DataTransformation:
                 self.df[col] = filtfilt(b, a, self.df[col])
             else:
                 self.df[col] = lfilter(b, a, self.df[col])
-                
+
         return self.df
 
+    def visualize_low_pass(self, movements: List = [], result_filepath: str = "."):
+        df_lowpass = self.df
+        df = self.df_original
+        movements = (
+            movements if movements else df.columns[df.columns.str.startswith("Label")]
+        )
+        for movement in movements:
+            all_movement_start_idx = list(
+                df[(df["Time difference (s)"] == 0)].index
+            ) + [df.shape[0]]
+            movement_start_idx = list(
+                df[(df["Time difference (s)"] == 0) & (df[movement] == 1)].index
+            )
+
+            fig = make_subplots(
+                rows=len(self.columns) // 3 + 1,
+                cols=3,
+                shared_yaxes=True,
+                vertical_spacing=0.08,
+                horizontal_spacing=0.02,
+                subplot_titles=[i.split(" (")[0] for i in self.columns],
+            )
+
+            for sensor_cnt, sensor_name in enumerate(self.columns):
+                for i in movement_start_idx[:1]:
+                    idx = all_movement_start_idx.index(i)
+                    start_idx = all_movement_start_idx[idx]
+                    end_idx = all_movement_start_idx[idx + 1] - 1
+                    df_plot = df.loc[start_idx:end_idx]
+                    df_plot_lowpass = df_lowpass.loc[start_idx:end_idx]
+                    legend_flag = sensor_cnt == 4
+                    fig.add_trace(
+                        go.Scatter(
+                            x=df_plot["Time difference (s)"],
+                            y=df_plot[sensor_name],
+                            mode="lines",
+                            marker=dict(color="blue"),
+                            name=f"Original",
+                            showlegend=legend_flag,
+                            legendgroup="normal",
+                        ),
+                        row=sensor_cnt // 3 + 1,
+                        col=sensor_cnt % 3 + 1,
+                    )
+                    fig.add_trace(
+                        go.Scatter(
+                            x=df_plot_lowpass["Time difference (s)"],
+                            y=df_plot_lowpass[sensor_name],
+                            mode="lines",
+                            marker=dict(size=3, color="red"),
+                            name=f"Low-pass",
+                            showlegend=legend_flag,
+                            legendgroup="outlier",
+                        ),
+                        row=sensor_cnt // 3 + 1,
+                        col=sensor_cnt % 3 + 1,
+                    )
+                    if sensor_cnt % 3 == 0:
+                        fig.update_yaxes(
+                            title_text=self.columns[sensor_cnt].split(" ")[-1][1:-1],
+                            row=sensor_cnt // 3 + 1,
+                            col=sensor_cnt % 3 + 1,
+                        )
+                    if sensor_cnt > 9:
+                        fig.update_xaxes(
+                            title_text="Time (s)",
+                            row=sensor_cnt // 3 + 1,
+                            col=sensor_cnt % 3 + 1,
+                        )
+            fig.update_layout(
+                width=800,
+                height=700,
+                showlegend=True,
+                font=dict(size=12),
+                title_text=f"{movement.split(' ')[1]}",
+            )
+            fig.update_annotations(font_size=12)
+            fig.write_html(
+                f"{result_filepath}/{movement.split(' ')[1].lower()}_sensor_lowpass.html"
+            )

--- a/src/non_temporal_modelling.py
+++ b/src/non_temporal_modelling.py
@@ -8,7 +8,6 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.model_selection import GridSearchCV, train_test_split
 
-
 # This class creates dfs splits that can be used by classification learning algorithms.
 class ClassificationPrepareData:
 
@@ -76,9 +75,25 @@ class ClassificationPrepareData:
             test_set_y = df.iloc[end_training_set:len(df.index), class_label_indices]
         # For non temporal data we use a standard function to randomly split the df.
         else:
-            training_set_X, test_set_X, training_set_y, test_set_y = train_test_split(df.iloc[:,features],
-                                                                                      df.iloc[:,class_label_indices], test_size=(1-training_frac), stratify=df.iloc[:,class_label_indices], random_state=random_state)
-        
+            df_head = df.drop_duplicates("ID", ignore_index=True)
+            training_set_X, test_set_X, training_set_y, test_set_y = train_test_split(
+                            df_head.iloc[:, features],
+                            df_head.iloc[:, class_label_indices],
+                            test_size=(1-training_frac),
+                            stratify=df_head.iloc[:, class_label_indices],
+                            random_state=random_state,
+                        )
+            training_id = training_set_X["ID"].values
+            testing_id = test_set_X["ID"].values
+            training_set_X, training_set_y = (
+                df[df["ID"].isin(training_id)].iloc[:, features],
+                df[df["ID"].isin(training_id)].iloc[:, class_label_indices],
+            )
+            test_set_X, test_set_y = (
+                df[df["ID"].isin(testing_id)].iloc[:, features],
+                df[df["ID"].isin(testing_id)].iloc[:, class_label_indices],
+            )
+
         print('Training set length is: ', len(training_set_X.index))
         print('Test set length is: ', len(test_set_X.index))
         

--- a/src/outlier_detection.py
+++ b/src/outlier_detection.py
@@ -2,29 +2,25 @@ from math import sqrt
 
 import numpy as np
 import pandas as pd
+import plotly.graph_objects as go
 from scipy import special
 from sklearn.mixture import GaussianMixture
+from typing import List
+from plotly.subplots import make_subplots
 
 # Class for outlier detection algorithms based on some distribution of the data. They
 # all consider only single points per row (i.e. one column).
 
-class OutlierDetectionDistribution:
 
-    def __init__(
-        self, 
-        df: pd.DataFrame,
-        columns: list[str]
-    ):
-        
+class OutlierDetectionDistribution:
+    def __init__(self, df: pd.DataFrame, columns: List[str]):
+
         self.df = df.copy()
         self.columns = columns
 
     # Finds outliers in the specified column of datatable and adds a binary column with
     # the same name extended with '_outlier' that expresses the result per data point.
-    def chauvenet(
-        self, 
-        C: int = 2
-    ) -> pd.DataFrame:
+    def chauvenet(self, C: int = 2) -> pd.DataFrame:
         # Taken partly from: https://www.astro.rug.nl/software/kapteyn/
 
         chauvenet_df = pd.DataFrame()
@@ -56,12 +52,9 @@ class OutlierDetectionDistribution:
 
     # Fits a mixture model towards the data expressed in col and adds a column with the probability
     # of observing the value given the mixture model.
-    def mixture_model(
-        self, 
-        n_components: int = 3
-    ) -> pd.DataFrame:
+    def mixture_model(self, n_components: int = 3) -> pd.DataFrame:
         # Fit a mixture model to our data.
-        
+
         mixture_df = pd.DataFrame()
         for col in self.columns:
             data = self.df[self.df[col].notnull()][col]
@@ -80,3 +73,93 @@ class OutlierDetectionDistribution:
             mixture_df = pd.concat([mixture_df, data_probs], axis=1)
 
         return mixture_df
+
+    def visualize_chauvenet_outlier(
+        self,
+        df_chauvenet: pd.DataFrame,
+        movements: List = [],
+        result_filepath: str = ".",
+    ):
+        movements = (
+            movements
+            if movements
+            else self.df.columns[self.df.columns.str.startswith("Label")]
+        )
+        for movement in movements:
+            all_movement_start_idx = list(
+                self.df[(self.df["Time difference (s)"] == 0)].index
+            ) + [self.df.shape[0]]
+            movement_start_idx = list(
+                self.df[
+                    (self.df["Time difference (s)"] == 0) & (self.df[movement] == 1)
+                ].index
+            )
+
+            fig = make_subplots(
+                rows=len(self.columns) // 3 + 1,
+                cols=3,
+                shared_yaxes=True,
+                vertical_spacing=0.08,
+                horizontal_spacing=0.02,
+                subplot_titles=[i.split(" (")[0] for i in self.columns],
+            )
+
+            for sensor_cnt, sensor_name in enumerate(self.columns):
+                df_normal = self.df[~df_chauvenet.iloc[:, sensor_cnt]]
+                df_outlier = self.df[df_chauvenet.iloc[:, sensor_cnt]]
+                for i in movement_start_idx[:1]:
+                    idx = all_movement_start_idx.index(i)
+                    start_idx = all_movement_start_idx[idx]
+                    end_idx = all_movement_start_idx[idx + 1] - 1
+                    df_plot = df_normal.loc[start_idx:end_idx]
+                    df_plot_outlier = df_outlier.loc[start_idx:end_idx]
+                    legend_flag = sensor_cnt == 4
+                    fig.add_trace(
+                        go.Scatter(
+                            x=df_plot["Time difference (s)"],
+                            y=df_plot[sensor_name],
+                            mode="lines",
+                            marker=dict(color="blue"),
+                            name=f"{movement} normal",
+                            showlegend=legend_flag,
+                            legendgroup="normal",
+                        ),
+                        row=sensor_cnt // 3 + 1,
+                        col=sensor_cnt % 3 + 1,
+                    )
+                    fig.add_trace(
+                        go.Scatter(
+                            x=df_plot_outlier["Time difference (s)"],
+                            y=df_plot_outlier[sensor_name],
+                            mode="markers",
+                            marker=dict(size=3, color="red"),
+                            name=f"{movement} outlier",
+                            showlegend=legend_flag,
+                            legendgroup="outlier",
+                        ),
+                        row=sensor_cnt // 3 + 1,
+                        col=sensor_cnt % 3 + 1,
+                    )
+                    if sensor_cnt % 3 == 0:
+                        fig.update_yaxes(
+                            title_text=self.columns[sensor_cnt].split(" ")[-1][1:-1],
+                            row=sensor_cnt // 3 + 1,
+                            col=sensor_cnt % 3 + 1,
+                        )
+                    if sensor_cnt > 9:
+                        fig.update_xaxes(
+                            title_text="Time (s)",
+                            row=sensor_cnt // 3 + 1,
+                            col=sensor_cnt % 3 + 1,
+                        )
+            fig.update_layout(
+                width=800,
+                height=700,
+                showlegend=True,
+                font=dict(size=12),
+                title_text=f"{movement.split(' ')[1]}",
+            )
+            fig.update_annotations(font_size=12)
+            fig.write_html(
+                f"{result_filepath}/{movement.split(' ')[1].lower()}_sensor_chauvenet_outlier.html"
+            )


### PR DESCRIPTION
Assign every movement an `ID`, and split the training and testing data based on this ID. For example, we have 104 movements in total, so there are `ID 0` to `ID 103` movements. Training dataset would be `ID 0`, `ID 5`, `ID 9`, etc., and testing dataset would be the rest of ID.